### PR TITLE
feat: add conversation flow prompt

### DIFF
--- a/src/main/java/com/example/mcp/ConversationPrompts.java
+++ b/src/main/java/com/example/mcp/ConversationPrompts.java
@@ -1,0 +1,24 @@
+package com.example.mcp;
+
+import org.springframework.ai.prompt.annotation.Prompt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConversationPrompts {
+
+    @Prompt(
+            name = "conversation_flow",
+            description = "Guides the assistant to create a conversation, send messages, and finally close the conversation using the available tools."
+    )
+    public String conversationFlow() {
+        return """
+                Follow this workflow when interacting with LivePerson:
+                1. Generate a random consumerId (for example, a UUID string) and keep it for this workflow.
+                2. Call `create_conversation` with that consumerId, firstName and lastName to start a new conversation. Save the returned conversationId.
+                3. For each user message, call `send_message` supplying the same consumerId, conversationId and the text to send.
+                4. When all messages have been exchanged and the task is complete, call `close_conversation` with that consumerId and conversationId to end the conversation.
+                For a new workflow, repeat from step 1 to obtain a new consumerId.
+                Only call these tools; do not fabricate responses.
+                """;
+    }
+}

--- a/src/main/java/com/example/mcp/McpServerApplication.java
+++ b/src/main/java/com/example/mcp/McpServerApplication.java
@@ -2,6 +2,8 @@ package com.example.mcp;
 
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.ai.prompt.PromptCallbackProvider;
+import org.springframework.ai.prompt.method.MethodPromptCallbackProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -17,5 +19,11 @@ public class McpServerApplication {
     ToolCallbackProvider conversationToolsProvider(ConversationTools tools) {
         // Auto-expose @Tool methods as MCP tools
         return MethodToolCallbackProvider.builder().toolObjects(tools).build();
+    }
+
+    @Bean
+    PromptCallbackProvider conversationPromptsProvider(ConversationPrompts prompts) {
+        // Auto-expose @Prompt methods as MCP prompts
+        return MethodPromptCallbackProvider.builder().promptObjects(prompts).build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         capabilities:
           tool: true
           resource: false
-          prompt: false
+          prompt: true
           completion: false
 
 lp:


### PR DESCRIPTION
## Summary
- enable prompt capability on the MCP server
- expose conversation flow prompt guiding agents to create, message, and close conversations
- instruct agents to generate and reuse a random consumer id during workflows

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689df181440c8329938b171abe866b08