### PR TITLE
feat: add conversation flow prompt

### DIFF
--- a/src/main/java/com/example/mcp/ConversationPrompts.java
+++ b/src/main/java/com/example/mcp/ConversationPrompts.java
@@ -1,0 +1,41 @@
+package com.example.mcp;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
+import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
+import io.modelcontextprotocol.spec.McpSchema.Role;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+@Configuration
+public class ConversationPrompts {
+
+    @Bean
+    public List<McpServerFeatures.SyncPromptSpecification> conversationPrompts() {
+        var prompt = new McpSchema.Prompt(
+                "conversation_flow",
+                "Guides the assistant to create a conversation, send messages, and finally close the conversation using the available tools.",
+                List.of());
+
+        var promptSpec = new McpServerFeatures.SyncPromptSpecification(prompt, (exchange, request) -> {
+            var userMessage = new PromptMessage(Role.USER, new TextContent("""
+                    Follow this workflow when interacting with LivePerson:
+                    1. Generate a random consumerId (for example, a UUID string) and keep it for this workflow.
+                    2. Call `create_conversation` with that consumerId, firstName and lastName to start a new conversation. Save the returned conversationId.
+                    3. For each user message, call `send_message` supplying the same consumerId, conversationId and the text to send.
+                    4. When all messages have been exchanged and the task is complete, call `close_conversation` with that consumerId and conversationId to end the conversation.
+                    For a new workflow, repeat from step 1 to obtain a new consumerId.
+                    Only call these tools; do not fabricate responses.
+                    """));
+            return new GetPromptResult("Instructions for the LivePerson conversation workflow", List.of(userMessage));
+        });
+
+        return List.of(promptSpec);
+    }
+}
+

--- a/src/main/java/com/example/mcp/ConversationPrompts.java
+++ b/src/main/java/com/example/mcp/ConversationPrompts.java
@@ -16,7 +16,7 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 public class ConversationPrompts {
 
     @Bean
-    public List<McpServerFeatures.SyncPromptSpecification> conversationPrompts() {
+    public List<McpServerFeatures.SyncPromptSpecification> prompts() {
         var prompt = new McpSchema.Prompt(
                 "conversation_flow",
                 "Guides the assistant to create a conversation, send messages, and finally close the conversation using the available tools.",

--- a/src/main/java/com/example/mcp/McpServerApplication.java
+++ b/src/main/java/com/example/mcp/McpServerApplication.java
@@ -5,7 +5,6 @@ import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import reactor.core.publisher.Hooks;
 
 @SpringBootApplication
 public class McpServerApplication {
@@ -18,4 +17,5 @@ public class McpServerApplication {
         // Auto-expose @Tool methods as MCP tools
         return MethodToolCallbackProvider.builder().toolObjects(tools).build();
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         capabilities:
           tool: true
           resource: false
-          prompt: false
+          prompt: true
           completion: false
 
 lp:


### PR DESCRIPTION
## Summary
- define LivePerson conversation workflow prompt using Spring AI prompt management
- remove manual prompt provider bean; tools remain auto-exposed

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689df181440c8329938b171abe866b08