### PR TITLE
Poll LivePerson messages and expose as MCP resource

### DIFF
--- a/src/main/java/com/example/mcp/ConversationResourceService.java
+++ b/src/main/java/com/example/mcp/ConversationResourceService.java
@@ -1,0 +1,176 @@
+package com.example.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema.GetResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.ResourceUpdated;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Maintains a resource view of LivePerson agent replies and polls the
+ * Messaging REST API for new messages every two seconds. The messages are
+ * exposed as an MCP resource using the URI pattern
+ * {@code conv://{consumerId}/{conversationId}/messages}.
+ */
+@Service
+public class ConversationResourceService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConversationResourceService.class);
+
+    private final LivePersonRestClient lp;
+
+    /** Tracks active conversations keyed by their resource URI. */
+    private final Map<String, ConversationState> conversations = new ConcurrentHashMap<>();
+
+    /** Subscribers waiting for updates on a given conversation resource. */
+    private final Map<String, Queue<Consumer<ResourceUpdated>>> subscribers = new ConcurrentHashMap<>();
+
+    public ConversationResourceService(LivePersonRestClient lp) {
+        this.lp = lp;
+    }
+
+    /** Register a conversation to start polling for messages. */
+    public void registerConversation(String consumerId, String conversationId) {
+        String uri = uriFor(consumerId, conversationId);
+        conversations.computeIfAbsent(uri, u -> new ConversationState(consumerId, conversationId));
+    }
+
+    /** Stop polling for a conversation. */
+    public void unregisterConversation(String consumerId, String conversationId) {
+        String uri = uriFor(consumerId, conversationId);
+        conversations.remove(uri);
+        subscribers.remove(uri);
+    }
+
+    /**
+     * Poll the LivePerson API for each active conversation and push updates to
+     * subscribers when new agent messages are found.
+     */
+    @Scheduled(fixedDelay = 2000L)
+    void poll() {
+        conversations.values().forEach(state -> {
+            state.pruneOldMessages();
+            try {
+                Map<String, Object> resp = lp.getDialogMessages(state.consumerId, state.conversationId, state.conversationId);
+                Object arr = resp.get("messages");
+                if (arr instanceof List<?> list) {
+                    list.forEach(state::ingestMessage);
+                }
+            } catch (Exception e) {
+                logger.warn("Polling messages failed for {}: {}", state.conversationId, e.getMessage());
+            }
+        });
+    }
+
+    /** List all available resources for the MCP server. */
+    public List<Resource> listResources() {
+        List<Resource> res = new ArrayList<>();
+        conversations.values().forEach(state ->
+                res.add(new Resource(state.uri,
+                        "Conversation messages for consumer " + state.consumerId + " conversation " + state.conversationId,
+                        null)));
+        return res;
+    }
+
+    /** Return the resource data for the given URI. */
+    public GetResourceResult getResource(String uri) {
+        ConversationState state = conversations.get(uri);
+        String text = "";
+        if (state != null) {
+            state.pruneOldMessages();
+            text = state.messages.stream().map(m -> m.text).collect(Collectors.joining("\n"));
+        }
+        return new GetResourceResult(uri, List.of(new TextResourceContents(text)));
+    }
+
+    /** Subscribe for updates to the given resource URI. */
+    public void subscribe(String uri, Consumer<ResourceUpdated> sink) {
+        subscribers.computeIfAbsent(uri, u -> new ConcurrentLinkedQueue<>()).add(sink);
+    }
+
+    private boolean notifySubscribers(String uri, String text) {
+        Queue<Consumer<ResourceUpdated>> list = subscribers.get(uri);
+        if (list != null && !list.isEmpty()) {
+            ResourceUpdated update = new ResourceUpdated(uri, List.of(new TextResourceContents(text)));
+            list.forEach(s -> s.accept(update));
+            return true;
+        }
+        return false;
+    }
+
+    private static String uriFor(String consumerId, String conversationId) {
+        return "conv://" + consumerId + "/" + conversationId + "/messages";
+    }
+
+    /**
+     * Internal state holder for a conversation's messages.
+     */
+    private class ConversationState {
+        final String consumerId;
+        final String conversationId;
+        final String uri;
+        long lastSeq = 0L;
+        final Queue<AgentMessage> messages = new ConcurrentLinkedQueue<>();
+
+        ConversationState(String consumerId, String conversationId) {
+            this.consumerId = consumerId;
+            this.conversationId = conversationId;
+            this.uri = uriFor(consumerId, conversationId);
+        }
+
+        void pruneOldMessages() {
+            long now = System.currentTimeMillis();
+            messages.removeIf(m -> now - m.timestamp > MESSAGE_TTL_MS);
+        }
+
+        @SuppressWarnings("unchecked")
+        void ingestMessage(Object messageObj) {
+            if (!(messageObj instanceof Map<?, ?> m)) return;
+
+            Number seqNum = (Number) m.getOrDefault("sequence", 0);
+            long seq = seqNum.longValue();
+            if (seq <= lastSeq) {
+                return; // already processed
+            }
+            lastSeq = seq;
+
+            Map<String, Object> body = (Map<String, Object>) m.getOrDefault("body", Map.of());
+            String text = String.valueOf(body.getOrDefault("text", ""));
+            String role = String.valueOf(m.getOrDefault("participantRole", ""));
+
+            if ("AGENT".equalsIgnoreCase(role)) {
+                AgentMessage msg = new AgentMessage(text);
+                messages.add(msg);
+                if (notifySubscribers(uri, text)) {
+                    messages.remove(msg);
+                }
+            }
+        }
+    }
+
+    private static final long MESSAGE_TTL_MS = 5 * 60 * 1000L;
+
+    private static class AgentMessage {
+        final String text;
+        final long timestamp;
+
+        AgentMessage(String text) {
+            this.text = text;
+            this.timestamp = System.currentTimeMillis();
+        }
+    }
+
+}
+

--- a/src/main/java/com/example/mcp/ConversationResources.java
+++ b/src/main/java/com/example/mcp/ConversationResources.java
@@ -1,0 +1,28 @@
+package com.example.mcp;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the conversation message resource with the MCP server.
+ */
+@Configuration
+public class ConversationResources {
+
+    private final ConversationResourceService service;
+
+    public ConversationResources(ConversationResourceService service) {
+        this.service = service;
+    }
+
+    @Bean
+    public McpServerFeatures.SyncResourceAdapter conversationResourceAdapter() {
+        return new McpServerFeatures.SyncResourceAdapter(
+                exchange -> service.listResources(),
+                (exchange, request) -> service.getResource(request.getUri()),
+                (exchange, request, consumer) -> service.subscribe(request.getUri(), consumer)
+        );
+    }
+}
+

--- a/src/main/java/com/example/mcp/ConversationResources.java
+++ b/src/main/java/com/example/mcp/ConversationResources.java
@@ -1,6 +1,7 @@
 package com.example.mcp;
 
 import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,12 +18,15 @@ public class ConversationResources {
     }
 
     @Bean
-    public McpServerFeatures.SyncResourceAdapter conversationResourceAdapter() {
-        return new McpServerFeatures.SyncResourceAdapter(
-                exchange -> service.listResources(),
-                (exchange, request) -> service.getResource(request.getUri()),
-                (exchange, request, consumer) -> service.subscribe(request.getUri(), consumer)
-        );
+    public java.util.List<McpServerFeatures.SyncResourceSpecification> conversationResources() {
+        McpSchema.Resource template = new McpSchema.Resource(
+                "conv://{consumerId}/{conversationId}/messages",
+                "LivePerson conversation messages",
+                "", "text/plain", null);
+        McpServerFeatures.SyncResourceSpecification spec = new McpServerFeatures.SyncResourceSpecification(
+                template,
+                (exchange, request) -> service.getResource(request.uri()));
+        return java.util.List.of(spec);
     }
 }
 

--- a/src/main/java/com/example/mcp/ConversationTools.java
+++ b/src/main/java/com/example/mcp/ConversationTools.java
@@ -14,10 +14,14 @@ import java.util.Map;
 public class ConversationTools {
     private final LivePersonRestClient lp;
     private final String brandId;
+    private final ConversationResourceService resources;
     private static final Logger log = LoggerFactory.getLogger(ConversationTools.class);
 
-    public ConversationTools(LivePersonRestClient lp, @Value("${lp.account-id}") String brandId) {
+    public ConversationTools(LivePersonRestClient lp,
+                             ConversationResourceService resources,
+                             @Value("${lp.account-id}") String brandId) {
         this.lp = lp;
+        this.resources = resources;
         this.brandId = brandId;
     }
 
@@ -56,6 +60,7 @@ public class ConversationTools {
                 }
             }
         }
+        resources.registerConversation(args.consumerId(), conversationId);
         return new CreateConversationResult(conversationId, mainDialogId, "CREATED");
     }
 
@@ -81,6 +86,7 @@ public class ConversationTools {
         String etag = entity.getHeaders().getFirst("ETag");
 
         lp.closeConversation(args.consumerId(), args.conversationId(), etag);
+        resources.unregisterConversation(args.consumerId(), args.conversationId());
         return new CloseConversationResult(args.conversationId(), "CLOSED");
     }
 

--- a/src/main/java/com/example/mcp/LivePersonRestClient.java
+++ b/src/main/java/com/example/mcp/LivePersonRestClient.java
@@ -138,4 +138,14 @@ public class LivePersonRestClient {
                 .retrieve()
                 .toEntity(Map.class);
     }
+
+    // --- Messages ---
+    public Map<String, Object> getDialogMessages(String consumerId, String convId, String dialogId) {
+        String url = baseUrl() + "/v1/conversations/" + convId + "/dialogs/" + dialogId + "/messages";
+        return restClient.get()
+                .uri(url)
+                .headers(h -> h.addAll(baseHeaders(consumerId)))
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {});
+    }
 }

--- a/src/main/java/com/example/mcp/McpServerApplication.java
+++ b/src/main/java/com/example/mcp/McpServerApplication.java
@@ -5,8 +5,10 @@ import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class McpServerApplication {
     public static void main(String[] args) {
         SpringApplication.run(McpServerApplication.class, args);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         sse-endpoint: /mcp/sse
         capabilities:
           tool: true
-          resource: false
+          resource: true
           prompt: true
           completion: false
 


### PR DESCRIPTION
## Summary
- index conversation resources by `conv://{consumerId}/{conversationId}/messages`
- drop agent messages after SSE delivery or 5 minutes of inactivity
- unregister resource upon conversation close
- use lock-free queues for subscriber and message buffers

## Testing
- `./mvnw -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e27d4d6f88329b2394a68db0c4606