### PR TITLE
Add tool to generate UUID and refer to it in prompt for generating a consumer id

### DIFF
--- a/src/main/java/com/gtrefs/liveperson/mcp/poc/ConversationPrompts.java
+++ b/src/main/java/com/gtrefs/liveperson/mcp/poc/ConversationPrompts.java
@@ -25,7 +25,7 @@ public class ConversationPrompts {
         var promptSpec = new McpServerFeatures.SyncPromptSpecification(prompt, (exchange, request) -> {
             var userMessage = new PromptMessage(Role.USER, new TextContent("""
                     Start the interactive LivePerson workflow:
-                       1. Generate a random consumerId (for example, a UUID string) and keep it for this workflow.
+                       1. Generate a random consumerId by calling generate_random_uuid and keep it for this workflow.
                        2. Ask the user for their first name and last name.
                        3. Once the user provides the names, call create_conversation using the new consumerId and the provided names.
                        4. Ask the user for the message they want to send.

--- a/src/main/java/com/gtrefs/liveperson/mcp/poc/ConversationTools.java
+++ b/src/main/java/com/gtrefs/liveperson/mcp/poc/ConversationTools.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class ConversationTools {
@@ -82,6 +83,14 @@ public class ConversationTools {
 
         lp.closeConversation(args.consumerId(), args.conversationId(), etag);
         return new CloseConversationResult(args.conversationId(), "CLOSED");
+    }
+
+    @Tool(
+            name = "generate_random_uuid",
+            description = "Generates and returns a random UUID."
+    )
+    public String generateRandomUUID() {
+        return UUID.randomUUID().toString();
     }
 
     // === Records ===


### PR DESCRIPTION
Provide a tool to generate a consumer id so that Gemini does not need to use Python or other tools for it.